### PR TITLE
feat(dns): add resolver options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ validated domain, provider name, provider version, and a report timestamp (UTC).
 - Strict mode for exact matches; standard mode warns when extras are present
 - Validates A/AAAA address records when configured
 - Configurable DMARC policy/RUA/RUF destinations and SPF policy/includes/IP entries
+- Optional custom DNS servers for lookups
 - Human, text, and JSON output; logging with UTC timestamps
 - Tested with Python 3.11+; formatted with `black`
 
@@ -151,6 +152,14 @@ These are compatible with Nagios/Icinga plugin exit codes.
 --txt NAME=VALUE              require TXT record values (repeatable)
 --txt-verification NAME=VALUE require TXT verification record values (repeatable)
 --skip-txt-verification       skip provider-required TXT verification checks
+```
+
+#### DNS options
+```text
+--dns-server SERVER   DNS server to use for lookups (repeatable; IP or hostname)
+--dns-timeout SECONDS per-query DNS timeout in seconds
+--dns-lifetime SECONDS total DNS query lifetime in seconds
+--dns-tcp             use TCP for DNS lookups
 ```
 
 #### Misc

--- a/src/provider_check/cli/detection.py
+++ b/src/provider_check/cli/detection.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from typing import Callable
 
+from ..dns_resolver import DnsResolver
+
 from .shared import _build_dmarc_required_tags, _parse_txt_inputs
 
 
@@ -13,6 +15,7 @@ def handle_detection(
     parser: object,
     report_time: str,
     *,
+    resolver: DnsResolver,
     detect_providers: Callable[..., object],
     default_top_n: int,
     format_detection_report: Callable[[object, str], str],
@@ -33,6 +36,7 @@ def handle_detection(
         args (object): Parsed CLI arguments.
         parser (object): Argument parser with an error() method.
         report_time (str): Report timestamp.
+        resolver (DnsResolver): DNS resolver to use for lookups.
         detect_providers (Callable[..., object]): Provider detection callback.
         default_top_n (int): Default number of candidates to return.
         format_detection_report (Callable[[object, str], str]): Report formatter.
@@ -50,7 +54,7 @@ def handle_detection(
     Returns:
         int: Exit code.
     """
-    report = detect_providers(args.domain, top_n=default_top_n)
+    report = detect_providers(args.domain, resolver=resolver, top_n=default_top_n)
     detection_output = format_detection_report(
         report,
         report_time,
@@ -74,6 +78,7 @@ def handle_detection(
             checker = dns_checker_cls(
                 args.domain,
                 provider,
+                resolver=resolver,
                 strict=args.strict,
                 dmarc_rua_mailto=args.dmarc_rua_mailto,
                 dmarc_ruf_mailto=args.dmarc_ruf_mailto,
@@ -121,6 +126,7 @@ def handle_detection(
         checker = dns_checker_cls(
             args.domain,
             provider,
+            resolver=resolver,
             strict=args.strict,
             dmarc_rua_mailto=args.dmarc_rua_mailto,
             dmarc_ruf_mailto=args.dmarc_ruf_mailto,

--- a/src/provider_check/cli/parser.py
+++ b/src/provider_check/cli/parser.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import logging
 import time
 
 from .. import __version__
-from .parsing import _parse_dmarc_pct
+from .parsing import _parse_dmarc_pct, _parse_positive_float
 
 
 def _setup_logging(verbosity: int) -> None:
@@ -42,6 +43,7 @@ def build_parser() -> argparse.ArgumentParser:
     target_group = parser.add_argument_group("Target")
     provider_group = parser.add_argument_group("Provider selection")
     output_group = parser.add_argument_group("Output")
+    dns_group = parser.add_argument_group("DNS")
     validation_group = parser.add_argument_group("Validation options")
     dmarc_group = parser.add_argument_group("Validation options DMARC")
     spf_group = parser.add_argument_group("SPF options")
@@ -115,6 +117,33 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_const",
         const="never",
         help="Disable colorized output",
+    )
+    dns_group.add_argument(
+        "--dns-server",
+        dest="dns_servers",
+        action="append",
+        default=[],
+        help="DNS server to use for lookups (repeatable; IP or hostname)",
+    )
+    dns_group.add_argument(
+        "--dns-timeout",
+        dest="dns_timeout",
+        type=functools.partial(_parse_positive_float, label="DNS timeout"),
+        default=None,
+        help="Per-query DNS timeout in seconds",
+    )
+    dns_group.add_argument(
+        "--dns-lifetime",
+        dest="dns_lifetime",
+        type=functools.partial(_parse_positive_float, label="DNS lifetime"),
+        default=None,
+        help="Total DNS query lifetime in seconds",
+    )
+    dns_group.add_argument(
+        "--dns-tcp",
+        dest="dns_tcp",
+        action="store_true",
+        help="Use TCP for DNS lookups",
     )
     validation_group.add_argument(
         "--strict",

--- a/src/provider_check/cli/parsing.py
+++ b/src/provider_check/cli/parsing.py
@@ -77,3 +77,25 @@ def _parse_provider_vars(raw_vars: List[str]) -> dict[str, str]:
             raise ValueError(f"Provider variable '{name}' was provided more than once")
         parsed[name] = value
     return parsed
+
+
+def _parse_positive_float(value: str, *, label: str) -> float:
+    """Parse a positive float value from CLI input.
+
+    Args:
+        value (str): String value to parse.
+        label (str): Label used in error messages.
+
+    Returns:
+        float: Parsed positive float value.
+
+    Raises:
+        argparse.ArgumentTypeError: If the value is invalid or non-positive.
+    """
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"{label} must be a positive number") from exc
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError(f"{label} must be a positive number")
+    return parsed

--- a/tests/test_cli_dns_servers.py
+++ b/tests/test_cli_dns_servers.py
@@ -1,0 +1,141 @@
+import pytest
+
+from provider_check.cli import main
+from provider_check.detection import DetectionReport
+from provider_check.provider_config import ProviderConfig
+
+
+def test_dns_server_option_passed_to_resolver_for_checks(monkeypatch):
+    import provider_check.cli as cli
+
+    provider = ProviderConfig(
+        provider_id="dummy",
+        name="Dummy",
+        version="1",
+        mx=None,
+        spf=None,
+        dkim=None,
+        txt=None,
+        dmarc=None,
+    )
+    monkeypatch.setattr(cli, "load_provider_config", lambda _selection: provider)
+    monkeypatch.setattr(cli, "resolve_provider_config", lambda prov, *_args, **_kwargs: prov)
+
+    captured = {}
+
+    class DummyResolver:
+        def __init__(self, nameservers=None, timeout=None, lifetime=None, use_tcp=False):
+            captured["nameservers"] = list(nameservers or [])
+            captured["timeout"] = timeout
+            captured["lifetime"] = lifetime
+            captured["use_tcp"] = use_tcp
+
+    class DummyChecker:
+        def __init__(self, *_args, **kwargs):
+            captured["resolver"] = kwargs.get("resolver")
+
+        def run_checks(self):
+            return []
+
+    monkeypatch.setattr(cli, "DnsResolver", DummyResolver)
+    monkeypatch.setattr(cli, "DNSChecker", DummyChecker)
+
+    code = main(
+        [
+            "example.com",
+            "--provider",
+            "dummy",
+            "--output",
+            "json",
+            "--dns-server",
+            "dns.example.test",
+            "--dns-server",
+            "1.1.1.1",
+            "--dns-timeout",
+            "2.5",
+            "--dns-lifetime",
+            "5",
+            "--dns-tcp",
+        ]
+    )
+
+    assert code == 0
+    assert captured["nameservers"] == ["dns.example.test", "1.1.1.1"]
+    assert captured["timeout"] == 2.5
+    assert captured["lifetime"] == 5.0
+    assert captured["use_tcp"] is True
+    assert isinstance(captured["resolver"], DummyResolver)
+
+
+def test_dns_server_option_passed_to_detection(monkeypatch):
+    import provider_check.cli as cli
+
+    captured = {}
+
+    class DummyResolver:
+        def __init__(self, nameservers=None, timeout=None, lifetime=None, use_tcp=False):
+            captured["nameservers"] = list(nameservers or [])
+            captured["timeout"] = timeout
+            captured["lifetime"] = lifetime
+            captured["use_tcp"] = use_tcp
+
+    def _fake_detect(_domain, *, resolver=None, top_n=None):
+        captured["resolver"] = resolver
+        return DetectionReport(
+            domain="example.com",
+            candidates=[],
+            selected=None,
+            ambiguous=False,
+            status="UNKNOWN",
+            top_n=top_n,
+        )
+
+    monkeypatch.setattr(cli, "DnsResolver", DummyResolver)
+    monkeypatch.setattr(cli, "detect_providers", _fake_detect)
+
+    code = main(
+        [
+            "example.com",
+            "--provider-detect",
+            "--output",
+            "json",
+            "--dns-server",
+            "dns.example.test",
+            "--dns-timeout",
+            "1.25",
+            "--dns-lifetime",
+            "3",
+        ]
+    )
+
+    assert code == 3
+    assert captured["nameservers"] == ["dns.example.test"]
+    assert captured["timeout"] == 1.25
+    assert captured["lifetime"] == 3.0
+    assert captured["use_tcp"] is False
+    assert isinstance(captured["resolver"], DummyResolver)
+
+
+def test_invalid_dns_server_reports_error(monkeypatch, capsys):
+    import provider_check.cli as cli
+
+    def _raise_value_error(*_args, **_kwargs):
+        raise ValueError("dns server invalid")
+
+    monkeypatch.setattr(cli, "DnsResolver", _raise_value_error)
+
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "example.com",
+                "--provider-detect",
+                "--output",
+                "json",
+                "--dns-server",
+                "bad",
+            ]
+        )
+
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "dns server invalid" in err

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -8,6 +8,7 @@ import pytest
 from provider_check.checker import RecordCheck
 from provider_check.cli import (
     _parse_dmarc_pct,
+    _parse_positive_float,
     _parse_provider_vars,
     _parse_txt_records,
     _setup_logging,
@@ -59,6 +60,20 @@ def test_parse_dmarc_pct_rejects_non_integer():
 def test_parse_dmarc_pct_rejects_out_of_range():
     with pytest.raises(ArgumentTypeError):
         _parse_dmarc_pct("101")
+
+
+def test_parse_positive_float_rejects_non_number():
+    with pytest.raises(ArgumentTypeError):
+        _parse_positive_float("n/a", label="DNS timeout")
+
+
+def test_parse_positive_float_rejects_non_positive():
+    with pytest.raises(ArgumentTypeError):
+        _parse_positive_float("0", label="DNS timeout")
+
+
+def test_parse_positive_float_accepts_value():
+    assert _parse_positive_float("1.5", label="DNS timeout") == 1.5
 
 
 def test_domain_required_without_list_providers(capsys):


### PR DESCRIPTION
Add CLI flags for custom servers, timeouts, and TCP, and wire them through the resolver with tests and docs.