### PR TITLE
fix(ci): optimize workflow triggers and concurrency

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ permissions:
   packages: read
   security-events: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     if: &skip_renovate >-

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: "0 3 * * 1"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   sync-repo-to-codeberg:
     if: &skip_renovate >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,19 @@ name: tests
 on:
   push:
     branches-ignore:
+      - codex/**
       - renovate/**
       - renovate-*
   pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.event.pull_request.head.ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   black:
@@ -22,6 +32,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install black
         run: python -m pip install black
@@ -40,6 +52,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Regenerate requirements files
         run: python scripts/update_requirements.py
@@ -58,6 +72,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install yamllint
         run: python -m pip install yamllint
@@ -83,6 +99,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: python -m pip install ".[test]"
@@ -101,6 +119,8 @@ jobs:
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.14"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: python -m pip install ".[test]"


### PR DESCRIPTION
## Summary
- reduce duplicate CI activity by refining tests workflow triggers for push and PR events
- exclude codex branches from push-triggered tests while keeping main push validation
- add workflow concurrency cancellation and minimal permissions updates
- add pip caching for Python setup steps in tests workflow jobs

## Validation
- ./.venv/bin/python -m black .
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m coverage run -m pytest
- ./.venv/bin/python -m coverage report -m --fail-under=100
- ./.venv/bin/python -m yamllint -c .yamllint src
