### PR TITLE
test(output): expand output mode coverage

### DIFF
--- a/tests/cli/test_cli_dmarc_flags.py
+++ b/tests/cli/test_cli_dmarc_flags.py
@@ -1,3 +1,5 @@
+import pytest
+
 from provider_check.cli import main
 from provider_check.provider_config import list_providers
 
@@ -11,7 +13,8 @@ class DummyChecker:
         return []
 
 
-def test_dmarc_flag_parsing(monkeypatch):
+@pytest.mark.parametrize("output_format", ["human", "text", "json"])
+def test_dmarc_flag_parsing(monkeypatch, output_format):
     captured = {}
 
     def _factory(*args, **kwargs):
@@ -28,6 +31,8 @@ def test_dmarc_flag_parsing(monkeypatch):
             "example.com",
             "--provider",
             provider_id,
+            "--output",
+            output_format,
             "--dmarc-subdomain-policy",
             "reject",
             "--dmarc-adkim",

--- a/tests/cli/test_cli_output_modes.py
+++ b/tests/cli/test_cli_output_modes.py
@@ -92,3 +92,23 @@ def test_text_output(
 
     assert code == 0
     assert "report for domain example.com" in capsys.readouterr().out
+
+
+def test_human_output(
+    patch_provider_resolution,
+    patch_dns_checker,
+    patch_cli_datetime,
+    make_provider,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Render provider checks in human format."""
+    patch_provider_resolution(make_provider(name="Dummy"))
+    patch_cli_datetime(datetime(2026, 1, 31, 19, 37, tzinfo=timezone.utc))
+    patch_dns_checker([make_record_check()])
+
+    code = main(["example.com", "--provider", "dummy", "--output", "human"])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "report for domain example.com" in output
+    assert "| Status" in output

--- a/tests/cli/test_provider_detect_flow.py
+++ b/tests/cli/test_provider_detect_flow.py
@@ -32,6 +32,28 @@ def test_provider_detect_outputs_json(
     assert payload["candidates"][0]["provider_id"] == "dummy"
 
 
+@pytest.mark.parametrize("output_format", ["text", "human"])
+def test_provider_detect_outputs_text_and_human(
+    output_format: str,
+    patch_cli_datetime,
+    patch_detection_report,
+    make_detection_candidate,
+    make_detection_report,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Return rendered text for non-JSON output modes."""
+    patch_cli_datetime(datetime(2026, 2, 2, 12, 0, tzinfo=timezone.utc))
+    candidate = make_detection_candidate()
+    patch_detection_report(make_detection_report(candidate))
+
+    code = main(["example.com", "--provider-detect", "--output", output_format])
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert "provider detection report for domain example.com" in output
+    assert "dummy (Dummy Provider" in output
+
+
 def test_provider_detect_limit_passed_to_detection(
     cli_module: Any,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- parametrize DMARC flag parsing test across human/text/json outputs
- add explicit human output assertion for provider check CLI rendering
- add provider-detect coverage for text and human output modes
- add runner run_checks output-dispatch coverage for text/human/json

## Validation
- ./.venv/bin/python -m black .
- ./.venv/bin/python -m pytest
- ./.venv/bin/python -m coverage run -m pytest
- ./.venv/bin/python -m coverage report -m --fail-under=100
- ./.venv/bin/python -m yamllint -c .yamllint src